### PR TITLE
fixes url to point to the actual location of imajes' repo

### DIFF
--- a/README
+++ b/README
@@ -1,1 +1,1 @@
-James Cox has taken over maintenance of Geokit. Head over to https://github.com/imajes/geokit-gem for the latest and greatest!
+James Cox has taken over maintenance of Geokit. Head over to https://github.com/imajes/geokit for the latest and greatest!


### PR DESCRIPTION
Hey.

imajes changed the name of the repository that the geokit gem is built from, this change will have the link in the readme point to the new location.

Thanks,

Corprew
