### PR TITLE
Updated link to new geokit url

### DIFF
--- a/README
+++ b/README
@@ -1,1 +1,1 @@
-James Cox has taken over maintenance of Geokit. Head over to https://github.com/imajes/geokit-gem for the latest and greatest!
+James Cox has taken over maintenance of Geokit. Head over to https://github.com/imajes/geokit for the latest and greatest!


### PR DESCRIPTION
The current URL leads to a 404 page
